### PR TITLE
Introduce failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ documentation = "https://johalun.github.io/sysctl-rs/index.html"
 [dependencies]
 libc = "^0.2.34"
 byteorder = "^1.0.0"
-errno = "^0.2.3"
+failure = "^0.1.1"
 


### PR DESCRIPTION
This PR introduces the [failure](https://crates.io/crates/failure) crate using the [Custom Fail Type Pattern](https://boats.gitlab.io/failure/custom-fail.html), allowing to match on SysctlError variants.