### PR TITLE
Struct interface

### DIFF
--- a/examples/iterate.rs
+++ b/examples/iterate.rs
@@ -1,0 +1,58 @@
+extern crate sysctl;
+use std::env;
+
+fn format_value(value: sysctl::CtlValue) -> String {
+    match value {
+        sysctl::CtlValue::None => "(none)".to_owned(),
+        sysctl::CtlValue::Int(i) => format!("{}", i),
+        sysctl::CtlValue::Uint(i) => format!("{}", i),
+        sysctl::CtlValue::Long(i) => format!("{}", i),
+        sysctl::CtlValue::Ulong(i) => format!("{}", i),
+        sysctl::CtlValue::U8(i) => format!("{}", i),
+        sysctl::CtlValue::U16(i) => format!("{}", i),
+        sysctl::CtlValue::U32(i) => format!("{}", i),
+        sysctl::CtlValue::U64(i) => format!("{}", i),
+        sysctl::CtlValue::S8(i) => format!("{}", i),
+        sysctl::CtlValue::S16(i) => format!("{}", i),
+        sysctl::CtlValue::S32(i) => format!("{}", i),
+        sysctl::CtlValue::S64(i) => format!("{}", i),
+        sysctl::CtlValue::Struct(_) => "(opaque struct)".to_owned(),
+        sysctl::CtlValue::Node(_) => "(node)".to_owned(),
+        sysctl::CtlValue::String(s) => s.to_owned(),
+        #[cfg(not(target_os = "macos"))]
+        sysctl::CtlValue::Temperature(t) => format!("{} °C", t.celsius()),
+    }
+}
+
+fn print_ctl(ctl: &sysctl::Ctl) {
+    let name = ctl.name().expect("Could not get name of control");
+
+    if let Ok(value) = ctl.value() {
+        println!("{}: {}", name, format_value(value));
+    }
+}
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+
+    let ctls = match args.len() {
+        1 => sysctl::CtlIter::root().filter_map(Result::ok),
+        2 => {
+            let root = sysctl::Ctl::new(&args[1]).expect("Could not get given root node.");
+
+            let value_type = root.value_type()
+                .expect("could not get value type of given sysctl");
+            if value_type != sysctl::CtlType::Node {
+                print_ctl(&root);
+                return;
+            }
+
+            root.into_iter().filter_map(Result::ok)
+        }
+        _ => panic!("more than 1 command-line argument given"),
+    };
+
+    for ctl in ctls {
+        print_ctl(&ctl);
+    }
+}


### PR DESCRIPTION
Work in Progress, builds on (merge these first)
- [X] #2 
- [X] #7
- [x] #9

Fixes #3

- [X] add OID versions of all public fn's taking `name` as str
- [X] Implement a struct interface for controls
- [X] Implement a function and method that allows getting the name for an OID
- [x] Allow iterating over nodes.
   - Remove major roadblocks for iterating over controls
      - [X] don't panic, at least try not to - handle errors where we can.
      - [X] check access flags before accessing values - return sensible errors when reading from a write-only control or writing to a read-only control
   - [X] implement a `CtlIter` iterator that implements `Iterate`
   - [x] implement `IntoIter` for `Ctl` - this probably makes sense only for `CtlType::Node` controls
- examples
   - [X] iteration
   - [x] struct interface
- [x] tests
  - [X] extend current tests for the struct interface
  - [X] implement tests for the oid2name functions
  - [x] test iteration
- [x] make sure docs are complete