### PR TITLE
oidfmt: Fix panic in CtlInfo.is_temperature()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,10 +213,7 @@ struct CtlInfo {
 #[cfg(not(target_os = "macos"))]
 impl CtlInfo {
     fn is_temperature(&self) -> bool {
-        match &self.fmt[0..2] {
-            "IK" => true,
-            _ => false,
-        }
+        self.fmt.starts_with("IK")
     }
 }
 


### PR DESCRIPTION
The `oidfmt` sysctl may return less than 2 bytes of format. In this case,
`CtlInfo.is_temperature()` would panic.

Instead of comparing the slice `self.fmt[0..2]` to `"IK"`, we now use
`self.fmt.starts_with("IK")`, which handles shorter strings gracefully.

# Steps to reproduce:

The following program panics on FreeBSD:
```rust
extern crate sysctl;

fn main() {
    let value = sysctl::value("kern.ipc.shmsegs");
    println!("kern.ipc.shmsegs: {:?}", value);
}
```