### PR TITLE
Update examples and expose the OID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "sysctl"
 version = "0.2.0"
-authors = ["Johannes Lundberg <johalun0@gmail.com>", "Ivan Temchenko <ivan.temchenko@yandex.ua>"]
+authors = [
+   "Johannes Lundberg <johalun0@gmail.com>",
+   "Ivan Temchenko <ivan.temchenko@yandex.ua>",
+   "Fabian Freyer <fabian.freyer@physik.tu-berlin.de>"
+   ]
 description = "Simplified interface to libc::sysctl"
 keywords = ["sysctl", "freebsd", "macos"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -23,12 +23,28 @@ Add to `Cargo.toml`
 
 ```toml
 [dependencies]
-sysctl = "0.1.4"
+sysctl = "0.2.0"
 ```
+
+### macos
+
+* Due to limitations in the sysctl(3) API, many of the methods of
+  the `Ctl` take a mutable reference to `self` on macos.
+* Sysctl descriptions are not available on macos.
+* Some tests failures are ignored, as the respective sysctls do not
+  exist on macos.
 
 ### Example
 
-sysctl comes with several examples, see the examples folder.
+sysctl comes with several examples, see the examples folder:
+
+* `value.rs`: shows how to get a sysctl value
+* `value_as.rs`: parsing values as structures
+* `value_oid_as.rs`: getting a sysctl from OID constants from the `libc` crate.
+* `set_value.rs`: shows how to set a sysctl value
+* `struct.rs`: reading data into a struct
+* `temperature.rs`: parsing temperatures
+* `iterate.rs`: showcases iteration over the sysctl tree
 
 Run with:
 
@@ -38,22 +54,18 @@ $ cargo run --example iterate
 
 Or in a separate crate:
 
-
 ```rust
 extern crate sysctl;
+use sysctl::{Ctl, CtlValue};
 
 fn main() {
-    let ctl = "kern.osrevision";
-    let d: String = sysctl::description(ctl).unwrap();
-    println!("Description: {:?}", d);
+    let ctl = Ctl::new("kern.osrevision");
+    println!("Description: {:?}", ctl.description().unwrap());
 
-    let val_enum = sysctl::value(ctl).unwrap();
-    if let sysctl::CtlValue::Int(val) = val_enum {
+    let val_enum = ctl.value().unwrap();
+    if let CtlValue::Int(val) = val_enum {
         println!("Value: {}", val);
     }
 }
 ```
-
-
-
 

--- a/examples/set_value.rs
+++ b/examples/set_value.rs
@@ -8,33 +8,35 @@ fn main() {
         "This example must be run as root"
     );
 
-    let ctl = "hw.usb.debug";
+    let ctl = sysctl::Ctl::new("hw.usb.debug").expect("could not get sysctl: hw.usb.debug");
 
-    println!("\nFlipping value of sysctl {}", ctl);
+    let name = ctl.name().expect("could not get sysctl name");
+    println!("\nFlipping value of sysctl {}", name);
 
-    let old_val_enum = sysctl::value(ctl).unwrap();
+    let old_val_enum = ctl.value().expect("could not set sysctl value");
 
     if let sysctl::CtlValue::Int(old_val) = old_val_enum {
         println!("Old value: {}", old_val);
 
-        let l = {
-            if old_val == 0 {
-                1
-            } else {
-                0
-            }
+        let target_val = match old_val {
+            0 => 1,
+            _ => 0,
         };
-        let new_val_enum = sysctl::set_value(ctl, sysctl::CtlValue::Int(l)).unwrap();
+
+        let target_val_enum = sysctl::CtlValue::Int(target_val);
+
+        let new_val_enum = ctl.set_value(target_val_enum).expect("could not set value");
 
         if let sysctl::CtlValue::Int(new_val) = new_val_enum {
-            if new_val == l {
+            if new_val == target_val {
                 println!("New value succcesfully set to: {}", new_val);
             } else {
                 println!("Error: Could not set new value");
             }
             println!("Restore old value");
 
-            sysctl::set_value(ctl, old_val_enum).unwrap();
+            ctl.set_value(old_val_enum)
+                .expect("could not restore old value");
         }
     }
 }

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -19,13 +19,15 @@ struct ClockInfo {
 }
 #[cfg(not(target_os = "macos"))]
 fn main() {
-    let ctl = "kern.clockrate";
-    println!("\nRead sysctl {} and parse result to struct ClockInfo", ctl);
+    let ctl = sysctl::Ctl::new("kern.clockrate").expect("could not get sysctl: kern.clockrate");
 
-    let d = sysctl::description(ctl).unwrap();
+    let name = ctl.name().expect("could not get sysctl name");
+    println!("Read sysctl {} and parse result to struct ClockInfo", name);
+
+    let d = ctl.description().expect("could not get sysctl description");
     println!("Description: {:?}", d);
 
-    let val_enum = sysctl::value(ctl).unwrap();
+    let val_enum = ctl.value().expect("could not get sysctl value");
     println!("ClockInfo raw data: {:?}", val_enum);
 
     if let sysctl::CtlValue::Struct(val) = val_enum {

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -1,13 +1,21 @@
 extern crate sysctl;
 #[cfg(not(target_os = "macos"))]
 fn main() {
-    let ctl = "dev.cpu.0.temperature";
-    println!("\nRead sysctl {}", ctl);
+    let ctl = match sysctl::Ctl::new("dev.cpu.0.temperature") {
+        Ok(c) => c,
+        Err(e) => {
+            println!("Couldn't get dev.cpu.0.temperature: {}", e);
+            return;
+        }
+    };
 
-    let d = sysctl::description(ctl).unwrap();
+    let name = ctl.name().expect("could not get sysctl name");
+    println!("Read sysctl {}", name);
+
+    let d = ctl.description().expect("could not get description");
     println!("Description: {:?}", d);
 
-    let val_enum = sysctl::value(ctl).unwrap();
+    let val_enum = ctl.value().expect("could not get value");
 
     if let sysctl::CtlValue::Temperature(val) = val_enum {
         println!(

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -1,19 +1,42 @@
 extern crate sysctl;
+
+use sysctl::{Ctl, CtlValue};
+
 #[cfg(not(target_os = "macos"))]
 fn main() {
-    let ctl = "kern.osrevision";
+    let ctl = Ctl::new("kern.osrevision").expect("could not get sysctl");
 
-    println!("\nRead sysctl {}", ctl);
+    let name = ctl.name().expect("could not get name");
 
-    let d: String = sysctl::description(ctl).unwrap();
-    println!("Description: {:?}", d);
+    println!("\nRead sysctl {}", name);
 
-    let val_enum = sysctl::value(ctl).unwrap();
+    let description = ctl.description().expect("could not get description");
 
-    if let sysctl::CtlValue::Int(val) = val_enum {
+    println!("Description: {:?}", description);
+
+    let val_enum = ctl.value().expect("could not get sysctl value");
+
+    if let CtlValue::Int(val) = val_enum {
         println!("Value: {}", val);
     }
 }
 
 #[cfg(target_os = "macos")]
-fn main() {}
+fn main() {
+    // on macos the `name` and `newp` parameters of the sysctl(3)
+    // syscall API are not marked `const`. This means the sysctl
+    // structure has to be mutable.
+    let ctl = Ctl::new("kern.osrevision").expect("could not get sysctl");
+
+    let name = ctl.name().expect("could not get name");
+
+    println!("\nRead sysctl {}", name);
+
+    // sysctl descriptions are not available on macos.
+
+    let val_enum = ctl.value().expect("could not get sysctl value");
+
+    if let CtlValue::Int(val) = val_enum {
+        println!("Value: {}", val);
+    }
+}

--- a/examples/value_as.rs
+++ b/examples/value_as.rs
@@ -37,11 +37,17 @@ impl fmt::Debug for LoadAvg {
 fn main() {
     // Generic type to pass to function will be inferred if not specified on RHS
     println!("\nRead sysctl kern.clockrate as struct directly");
-    let val: Box<ClockInfo> = sysctl::value_as("kern.clockrate").unwrap();
+    let val: Box<ClockInfo> = sysctl::Ctl::new("kern.clockrate")
+        .expect("could not get sysctl: kern.clockrate")
+        .value_as()
+        .expect("could not read sysctl as struct");
     println!("{:?}", val);
 
     // Pass type LoadAvg to generic function
     println!("\nRead sysctl vm.loadavg as struct directly");
-    let val = sysctl::value_as::<LoadAvg>("vm.loadavg").unwrap();
+    let val = sysctl::Ctl::new("vm.loadavg")
+        .expect("could not get sysctl: vm.loadavg")
+        .value_as::<LoadAvg>()
+        .expect("could not read sysctl as LoadAvg");
     println!("{:?}", val);
 }

--- a/examples/value_oid_as.rs
+++ b/examples/value_oid_as.rs
@@ -13,16 +13,9 @@ struct ClockInfo {
     stathz: c_int, /* statistics clock frequency */
     profhz: c_int, /* profiling clock frequency */
 }
-#[cfg(not(target_os = "macos"))]
+
 fn main() {
     let oid: Vec<i32> = vec![libc::CTL_KERN, libc::KERN_CLOCKRATE];
-    let val: Box<ClockInfo> = sysctl::value_oid_as(&oid).unwrap();
-    println!("{:?}", val);
-}
-
-#[cfg(target_os = "macos")]
-fn main() {
-    let mut oid: Vec<i32> = vec![libc::CTL_KERN, libc::KERN_CLOCKRATE];
-    let val: Box<ClockInfo> = sysctl::value_oid_as(&mut oid).unwrap();
+    let val: Box<ClockInfo> = sysctl::Ctl { oid }.value_as().expect("could not get value");
     println!("{:?}", val);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1398,7 +1398,7 @@ pub fn next_oid(oid: &Vec<c_int>) -> Result<Option<Vec<c_int>>, SysctlError> {
 /// This struct represents a system control.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Ctl {
-    oid: Vec<c_int>,
+    pub oid: Vec<c_int>,
 }
 
 impl FromStr for Ctl {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,23 +7,32 @@
 //! extern crate sysctl;
 //! #[cfg(not(target_os = "macos"))]
 //! fn main() {
+//!     let ctl = sysctl::Ctl::new("kern.osrevision")
+//!         .expect("could not get sysctl");
 //!
-//!     let ctl = "kern.osrevision";
+//!     let d = ctl.description()
+//!         .expect("could not get description");
 //!
-//!     let d: String = sysctl::description(ctl).unwrap();
 //!     println!("Description: {:?}", d);
 //!
-//!     let val_enum = sysctl::value(ctl).unwrap();
+//!     let val_enum = ctl.value()
+//!         .expect("could not get value");
+//!
 //!     if let sysctl::CtlValue::Int(val) = val_enum {
 //!         println!("Value: {}", val);
 //!     }
 //! }
+//!
 //! #[cfg(target_os = "macos")]
 //! fn main() {
+//!     let mut ctl = sysctl::Ctl::new("kern.osrevision")
+//!         .expect("could not get sysctl");
 //!
-//!     let ctl = "kern.osrevision";
+//!     // description is not available on macos
 //!
-//!     let val_enum = sysctl::value(ctl).unwrap();
+//!     let val_enum = ctl.value()
+//!         .expect("could not get value");
+//!
 //!     if let sysctl::CtlValue::Int(val) = val_enum {
 //!         println!("Value: {}", val);
 //!     }
@@ -59,20 +68,20 @@ extern crate libc;
 #[macro_use]
 extern crate failure;
 
-use libc::{c_int, c_uchar, c_uint, c_void};
 use libc::sysctl;
 use libc::BUFSIZ;
+use libc::{c_int, c_uchar, c_uint, c_void};
 
+use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use std::cmp;
 use std::convert;
+#[cfg(not(target_os = "macos"))]
+use std::f32;
 use std::io;
 use std::mem;
 use std::ptr;
 use std::str;
 use std::str::FromStr;
-#[cfg(not(target_os = "macos"))]
-use std::f32;
-use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 
 // CTL* constants belong to libc crate but have not been added there yet.
 // They will be removed from here once in the libc crate.
@@ -342,16 +351,10 @@ pub enum SysctlError {
     ExtractionError,
 
     #[fail(display = "IO Error: {}", _0)]
-    IoError(
-        #[cause]
-        io::Error
-    ),
+    IoError(#[cause] io::Error),
 
     #[fail(display = "Error parsing UTF-8 data: {}", _0)]
-    Utf8Error(
-        #[cause]
-        str::Utf8Error
-    ),
+    Utf8Error(#[cause] str::Utf8Error),
 
     #[fail(display = "Value is not readable")]
     NoReadAccess,
@@ -359,7 +362,11 @@ pub enum SysctlError {
     #[fail(display = "Value is not writeable")]
     NoWriteAccess,
 
-    #[fail(display = "sysctl returned a short read: read {} bytes, while a size of {} was reported", read, reported)]
+    #[fail(
+        display = "sysctl returned a short read: read {} bytes, while a size of {} was reported",
+        read,
+        reported
+    )]
     ShortRead { read: usize, reported: usize },
 }
 
@@ -370,8 +377,14 @@ pub enum SysctlError {
 /// extern crate sysctl;
 /// #[cfg(not(target_os = "macos"))]
 /// fn main() {
-///     let val_enum = sysctl::value("dev.cpu.0.temperature").unwrap();
-///     if let sysctl::CtlValue::Temperature(val) = val_enum {
+/// #   let ctl = match sysctl::Ctl::new("dev.cpu.0.temperature") {
+/// #       Ok(c) => c,
+/// #       Err(e) => {
+/// #           println!("Couldn't get dev.cpu.0.temperature: {}", e);
+/// #           return;
+/// #       }
+/// #   };
+///     if let Ok(sysctl::CtlValue::Temperature(val)) = ctl.value() {
 ///         println!("Temperature: {:.2}K, {:.2}F, {:.2}C",
 ///                  val.kelvin(),
 ///                  val.fahrenheit(),
@@ -1062,7 +1075,10 @@ pub fn value_oid_as<T>(oid: &mut Vec<i32>) -> Result<Box<T>, SysctlError> {
 /// extern crate sysctl;
 ///
 /// fn main() {
+/// #   let old_value = sysctl::value("hw.usb.debug").unwrap();
 ///     println!("{:?}", sysctl::set_value("hw.usb.debug", sysctl::CtlValue::Int(1)));
+/// #   // restore old value
+/// #   sysctl::set_value("hw.usb.debug", old_value);
 /// }
 /// ```
 #[cfg(not(target_os = "macos"))]
@@ -1434,8 +1450,8 @@ impl Ctl {
     /// # Example
     ///
     /// ```
-    /// extern crate sysctl;
-    /// use sysctl::Ctl;
+    /// # extern crate sysctl;
+    /// # use sysctl::Ctl;
     /// let ctl = Ctl::new("kern.osrelease").expect("could not get sysctl");
     /// assert_eq!(ctl.name().expect("could not get name"), "kern.osrelease");
     /// ```
@@ -1449,13 +1465,12 @@ impl Ctl {
     /// # Example
     ///
     /// ```
-    /// extern crate sysctl;
-    /// use sysctl::{Ctl, CtlType};
-    ///
-    /// let osrelease = Ctl::new("kern.osrelease")
+    /// # extern crate sysctl;
+    /// # use sysctl::{Ctl, CtlType};
+    /// let ctl = Ctl::new("kern.osrelease")
     ///     .expect("Could not get kern.osrelease sysctl");
-    /// let value_type = osrelease.value_type()
-    ///         .expect("Could notget kern.osrelease value type");
+    /// let value_type = ctl.value_type()
+    ///         .expect("Could not get kern.osrelease value type");
     /// assert_eq!(value_type, CtlType::String);
     /// ```
     pub fn value_type(self: &Self) -> Result<CtlType, SysctlError> {
@@ -1597,14 +1612,11 @@ impl Ctl {
     /// fn main() {
     ///     let usbdebug = Ctl::new("hw.usb.debug")
     ///         .expect("could not get hw.usb.debug control");
-    ///     let original = usbdebug.value()
-    ///         .expect("could not get value");
-    ///     let set = usbdebug.set_value(sysctl::CtlValue::Int(0));
-    ///     println!("hw.usb.debug: {:?} -> {:?}", original, set);
+    /// #   let original = usbdebug.value()
+    /// #       .expect("could not get value");
     ///     let set = usbdebug.set_value(sysctl::CtlValue::Int(1));
-    ///     println!("hw.usb.debug: 0 -> {:?}", set);
-    ///     let reset = usbdebug.set_value(original);
-    ///     println!("hw.usb.debug: 1 -> {:?}", reset);
+    ///     println!("hw.usb.debug: -> {:?}", set);
+    /// #   usbdebug.set_value(original).unwrap();
     /// }
     #[cfg(not(target_os = "macos"))]
     pub fn set_value(self: &Self, value: CtlValue) -> Result<CtlValue, SysctlError> {
@@ -1622,14 +1634,11 @@ impl Ctl {
     /// fn main() {
     ///     let usbdebug = Ctl::new("hw.usb.debug")
     ///         .expect("could not get hw.usb.debug control");
-    ///     let original = usbdebug.value()
-    ///         .expect("could not get value");
-    ///     let set = usbdebug.set_value(sysctl::CtlValue::Int(0));
-    ///     println!("hw.usb.debug: {:?} -> {:?}", original, set);
+    /// #   let original = usbdebug.value()
+    /// #       .expect("could not get value");
     ///     let set = usbdebug.set_value(sysctl::CtlValue::Int(1));
-    ///     println!("hw.usb.debug: 0 -> {:?}", set);
-    ///     let reset = usbdebug.set_value(original);
-    ///     println!("hw.usb.debug: 1 -> {:?}", reset);
+    ///     println!("hw.usb.debug: -> {:?}", set);
+    /// #   usbdebug.set_value(original).unwrap();
     /// }
     #[cfg(target_os = "macos")]
     pub fn set_value(self: &Self, value: CtlValue) -> Result<CtlValue, SysctlError> {
@@ -1761,7 +1770,8 @@ mod tests {
         assert_eq!(name, "kern.osrevision");
 
         let ctl = Ctl { oid };
-        let name = ctl.name()
+        let name = ctl
+            .name()
             .expect("Could not get name of kern.osrevision sysctl.");
         assert_eq!(name, "kern.osrevision");
     }


### PR DESCRIPTION
* needed to expose the OID for the value_oid_as example, so there's a use case for this.
* fixes #10, and also restores hw.usb.debug to the original value. Hide some of the docstest setup and teardown code from the examples.
* as discussed on IRC, add myself to the authors