### PR TITLE
S64 is a signed integer.

### DIFF
--- a/src/ctl_value.rs
+++ b/src/ctl_value.rs
@@ -21,7 +21,7 @@ pub enum CtlValue {
     Node(Vec<u8>),
     Int(i32),
     String(String),
-    S64(u64),
+    S64(i64),
     Struct(Vec<u8>),
     Uint(u32),
     Long(i64),

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -60,7 +60,7 @@ pub fn temperature(info: &CtlInfo, val: &Vec<u8>) -> Result<CtlValue, SysctlErro
 
     match info.ctl_type {
         CtlType::Int => make_temp(byteorder::LittleEndian::read_i32(&val) as f32),
-        CtlType::S64 => make_temp(byteorder::LittleEndian::read_u64(&val) as f32),
+        CtlType::S64 => make_temp(byteorder::LittleEndian::read_i64(&val) as f32),
         CtlType::Uint => make_temp(byteorder::LittleEndian::read_u32(&val) as f32),
         CtlType::Long => make_temp(byteorder::LittleEndian::read_i64(&val) as f32),
         CtlType::Ulong => make_temp(byteorder::LittleEndian::read_u64(&val) as f32),

--- a/src/unix/funcs.rs
+++ b/src/unix/funcs.rs
@@ -244,7 +244,7 @@ pub fn value_oid(oid: &Vec<i32>) -> Result<CtlValue, SysctlError> {
                 .map_err(|e| SysctlError::Utf8Error(e))
                 .map(|s| CtlValue::String(s.into())),
         },
-        CtlType::S64 => Ok(CtlValue::S64(byteorder::LittleEndian::read_u64(&val))),
+        CtlType::S64 => Ok(CtlValue::S64(byteorder::LittleEndian::read_i64(&val))),
         CtlType::Struct => Ok(CtlValue::Struct(val)),
         CtlType::Uint => Ok(CtlValue::Uint(byteorder::LittleEndian::read_u32(&val))),
         CtlType::Long => Ok(CtlValue::Long(byteorder::LittleEndian::read_i64(&val))),
@@ -326,7 +326,7 @@ pub fn value_oid(oid: &mut Vec<i32>) -> Result<CtlValue, SysctlError> {
             Ok(s) => Ok(CtlValue::String(s.into())),
             Err(e) => Err(SysctlError::Utf8Error(e)),
         },
-        CtlType::S64 => Ok(CtlValue::S64(byteorder::LittleEndian::read_u64(&val))),
+        CtlType::S64 => Ok(CtlValue::S64(byteorder::LittleEndian::read_i64(&val))),
         CtlType::Struct => Ok(CtlValue::Struct(val)),
         CtlType::Uint => Ok(CtlValue::Uint(byteorder::LittleEndian::read_u32(&val))),
         CtlType::Long => Ok(CtlValue::Long(byteorder::LittleEndian::read_i64(&val))),


### PR DESCRIPTION
CTLTYPE_S64 is a signed integer, but the value declaration makes it unsigned.

Relevant FreeBSD src: https://github.com/freebsd/freebsd/blob/master/sys/sys/sysctl.h#L73

Tested on FreeBSD 12, but I think I found all the S64 instances in the other supported platforms. The size calculation in min_type_size() already used i64.