### PR TITLE
Replace deprecated try! with ?

### DIFF
--- a/examples/value.rs
+++ b/examples/value.rs
@@ -14,10 +14,10 @@ const CTLNAMES: &[&str] = &["kernel.ostype", "kernel/ostype", "/proc/sys/kernel/
 
 fn print_ctl(ctlname: &str) -> Result<(), sysctl::SysctlError> {
     println!("Reading '{}'", ctlname);
-    let ctl = try!(sysctl::Ctl::new(ctlname));
-    let desc = try!(ctl.description());
+    let ctl = sysctl::Ctl::new(ctlname)?;
+    let desc = ctl.description()?;
     println!("Description: {}", desc);
-    let val = try!(ctl.value());
+    let val = ctl.value()?;
     println!("Value: {}", val);
     Ok(())
 }

--- a/examples/value_string.rs
+++ b/examples/value_string.rs
@@ -15,10 +15,10 @@ const CTLNAMES: &[&str] = &["kernel.overflowuid"];
 
 fn print_ctl(ctlname: &str) -> Result<(), sysctl::SysctlError> {
     println!("Reading '{}'", ctlname);
-    let ctl = try!(sysctl::Ctl::new(ctlname));
-    let description = try!(ctl.description());
+    let ctl = sysctl::Ctl::new(ctlname)?;
+    let description = ctl.description()?;
     println!("Description: {}", description);
-    let val_string = try!(ctl.value_string());
+    let val_string = ctl.value_string()?;
     println!("Value: {}", val_string);
     Ok(())
 }

--- a/src/ctl_value.rs
+++ b/src/ctl_value.rs
@@ -173,5 +173,4 @@ mod tests_unix {
         };
         assert_eq!(info.struct_type(), None);
     }
-
 }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -120,5 +120,4 @@ mod tests_freebsd {
             assert!(false);
         }
     }
-
 }

--- a/src/unix/ctl.rs
+++ b/src/unix/ctl.rs
@@ -88,7 +88,7 @@ impl Sysctl for Ctl {
 
     #[cfg(not(target_os = "macos"))]
     fn set_value_string(&self, value: &str) -> Result<String, SysctlError> {
-        let ctl_type = try!(self.value_type());
+        let ctl_type = self.value_type()?;
         println!("type {:?}", ctl_type);
         let _ = match ctl_type {
             CtlType::String => set_oid_value(&self.oid, CtlValue::String(value.to_owned())),
@@ -115,7 +115,7 @@ impl Sysctl for Ctl {
 
     #[cfg(target_os = "macos")]
     fn set_value_string(&self, value: &str) -> Result<String, SysctlError> {
-        let ctl_type = try!(self.value_type());
+        let ctl_type = self.value_type()?;
         let mut oid = self.oid.clone();
         let _ = match ctl_type {
             CtlType::String => set_oid_value(&mut oid, CtlValue::String(value.to_owned())),

--- a/src/unix/funcs.rs
+++ b/src/unix/funcs.rs
@@ -173,7 +173,7 @@ pub fn oidfmt(oid: &[libc::c_int]) -> Result<CtlInfo, SysctlError> {
 
 #[cfg(not(target_os = "macos"))]
 pub fn value_oid(oid: &Vec<i32>) -> Result<CtlValue, SysctlError> {
-    let info: CtlInfo = try!(oidfmt(&oid));
+    let info: CtlInfo = oidfmt(&oid)?;
 
     // Check if the value is readable
     if !(info.flags & CTLFLAG_RD == CTLFLAG_RD) {
@@ -262,7 +262,7 @@ pub fn value_oid(oid: &Vec<i32>) -> Result<CtlValue, SysctlError> {
 
 #[cfg(target_os = "macos")]
 pub fn value_oid(oid: &mut Vec<i32>) -> Result<CtlValue, SysctlError> {
-    let info: CtlInfo = try!(oidfmt(&oid));
+    let info: CtlInfo = oidfmt(&oid)?;
 
     // Check if the value is readable
     if !(info.flags & CTLFLAG_RD == CTLFLAG_RD) {
@@ -345,7 +345,7 @@ pub fn value_oid(oid: &mut Vec<i32>) -> Result<CtlValue, SysctlError> {
 
 #[cfg(not(target_os = "macos"))]
 pub fn value_oid_as<T>(oid: &Vec<i32>) -> Result<Box<T>, SysctlError> {
-    let val_enum = try!(value_oid(oid));
+    let val_enum = value_oid(oid)?;
 
     // Some structs are apparently reported as Node so this check is invalid..
     // let ctl_type = CtlType::from(&val_enum);
@@ -389,7 +389,7 @@ pub fn value_oid_as<T>(oid: &Vec<i32>) -> Result<Box<T>, SysctlError> {
 
 #[cfg(target_os = "macos")]
 pub fn value_oid_as<T>(oid: &mut Vec<i32>) -> Result<Box<T>, SysctlError> {
-    let val_enum = try!(value_oid(oid));
+    let val_enum = value_oid(oid)?;
 
     // Some structs are apparently reported as Node so this check is invalid..
     // let ctl_type = CtlType::from(&val_enum);
@@ -461,7 +461,7 @@ fn value_to_bytes(value: CtlValue) -> Result<Vec<u8>, SysctlError> {
 
 #[cfg(not(target_os = "macos"))]
 pub fn set_oid_value(oid: &Vec<libc::c_int>, value: CtlValue) -> Result<CtlValue, SysctlError> {
-    let info: CtlInfo = try!(oidfmt(&oid));
+    let info: CtlInfo = oidfmt(&oid)?;
 
     // Check if the value is writeable
     if !(info.flags & CTLFLAG_WR == CTLFLAG_WR) {
@@ -497,7 +497,7 @@ pub fn set_oid_value(oid: &Vec<libc::c_int>, value: CtlValue) -> Result<CtlValue
 
 #[cfg(target_os = "macos")]
 pub fn set_oid_value(oid: &mut Vec<libc::c_int>, value: CtlValue) -> Result<CtlValue, SysctlError> {
-    let info: CtlInfo = try!(oidfmt(&oid));
+    let info: CtlInfo = oidfmt(&oid)?;
 
     // Check if the value is writeable
     if !(info.flags & CTLFLAG_WR == CTLFLAG_WR) {
@@ -747,7 +747,6 @@ mod tests {
             .expect("Could notget kern.osrevision value type");
         assert_eq!(value_type, crate::CtlType::Int);
     }
-
 }
 
 #[cfg(all(test, target_os = "freebsd"))]


### PR DESCRIPTION
This is a purely mechanical change to replace try! with ?, since try! generates a warning on newer rustc.

Also ran cargo fmt, which did some unrelated whitespace tidying.

Tested on FreeBSD 12.