### PR TITLE
Fixes clippy lints

### DIFF
--- a/src/ctl_type.rs
+++ b/src/ctl_type.rs
@@ -47,24 +47,24 @@ impl std::convert::From<u32> for CtlType {
 impl std::convert::From<&CtlValue> for CtlType {
     fn from(t: &CtlValue) -> Self {
         match t {
-            &CtlValue::None => CtlType::None,
-            &CtlValue::Node(_) => CtlType::Node,
-            &CtlValue::Int(_) => CtlType::Int,
-            &CtlValue::String(_) => CtlType::String,
-            &CtlValue::S64(_) => CtlType::S64,
-            &CtlValue::Struct(_) => CtlType::Struct,
-            &CtlValue::Uint(_) => CtlType::Uint,
-            &CtlValue::Long(_) => CtlType::Long,
-            &CtlValue::Ulong(_) => CtlType::Ulong,
-            &CtlValue::U64(_) => CtlType::U64,
-            &CtlValue::U8(_) => CtlType::U8,
-            &CtlValue::U16(_) => CtlType::U16,
-            &CtlValue::S8(_) => CtlType::S8,
-            &CtlValue::S16(_) => CtlType::S16,
-            &CtlValue::S32(_) => CtlType::S32,
-            &CtlValue::U32(_) => CtlType::U32,
+            CtlValue::None => CtlType::None,
+            CtlValue::Node(_) => CtlType::Node,
+            CtlValue::Int(_) => CtlType::Int,
+            CtlValue::String(_) => CtlType::String,
+            CtlValue::S64(_) => CtlType::S64,
+            CtlValue::Struct(_) => CtlType::Struct,
+            CtlValue::Uint(_) => CtlType::Uint,
+            CtlValue::Long(_) => CtlType::Long,
+            CtlValue::Ulong(_) => CtlType::Ulong,
+            CtlValue::U64(_) => CtlType::U64,
+            CtlValue::U8(_) => CtlType::U8,
+            CtlValue::U16(_) => CtlType::U16,
+            CtlValue::S8(_) => CtlType::S8,
+            CtlValue::S16(_) => CtlType::S16,
+            CtlValue::S32(_) => CtlType::S32,
+            CtlValue::U32(_) => CtlType::U32,
             #[cfg(target_os = "freebsd")]
-            &CtlValue::Temperature(_) => CtlType::Temperature,
+            CtlValue::Temperature(_) => CtlType::Temperature,
         }
     }
 }
@@ -76,27 +76,27 @@ impl std::convert::From<CtlValue> for CtlType {
 }
 
 impl CtlType {
-    pub fn min_type_size(self: &Self) -> usize {
+    pub fn min_type_size(&self) -> usize {
         match self {
-            &CtlType::None => 0,
-            &CtlType::Node => 0,
-            &CtlType::Int => std::mem::size_of::<libc::c_int>(),
-            &CtlType::String => 0,
-            &CtlType::S64 => std::mem::size_of::<i64>(),
-            &CtlType::Struct => 0,
-            &CtlType::Uint => std::mem::size_of::<libc::c_uint>(),
-            &CtlType::Long => std::mem::size_of::<libc::c_long>(),
-            &CtlType::Ulong => std::mem::size_of::<libc::c_ulong>(),
-            &CtlType::U64 => std::mem::size_of::<u64>(),
-            &CtlType::U8 => std::mem::size_of::<u8>(),
-            &CtlType::U16 => std::mem::size_of::<u16>(),
-            &CtlType::S8 => std::mem::size_of::<i8>(),
-            &CtlType::S16 => std::mem::size_of::<i16>(),
-            &CtlType::S32 => std::mem::size_of::<i32>(),
-            &CtlType::U32 => std::mem::size_of::<u32>(),
+            CtlType::None => 0,
+            CtlType::Node => 0,
+            CtlType::Int => std::mem::size_of::<libc::c_int>(),
+            CtlType::String => 0,
+            CtlType::S64 => std::mem::size_of::<i64>(),
+            CtlType::Struct => 0,
+            CtlType::Uint => std::mem::size_of::<libc::c_uint>(),
+            CtlType::Long => std::mem::size_of::<libc::c_long>(),
+            CtlType::Ulong => std::mem::size_of::<libc::c_ulong>(),
+            CtlType::U64 => std::mem::size_of::<u64>(),
+            CtlType::U8 => std::mem::size_of::<u8>(),
+            CtlType::U16 => std::mem::size_of::<u16>(),
+            CtlType::S8 => std::mem::size_of::<i8>(),
+            CtlType::S16 => std::mem::size_of::<i16>(),
+            CtlType::S32 => std::mem::size_of::<i32>(),
+            CtlType::U32 => std::mem::size_of::<u32>(),
             // Added custom types below
             #[cfg(target_os = "freebsd")]
-            &CtlType::Temperature => 0,
+            CtlType::Temperature => 0,
         }
     }
 }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -41,7 +41,7 @@ impl Temperature {
     }
 }
 
-pub fn temperature(info: &CtlInfo, val: &Vec<u8>) -> Result<CtlValue, SysctlError> {
+pub fn temperature(info: &CtlInfo, val: &[u8]) -> Result<CtlValue, SysctlError> {
     let prec: u32 = {
         match info.fmt.len() {
             l if l > 2 => match info.fmt[2..3].parse::<u32>() {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -119,6 +119,7 @@ pub trait Sysctl {
     /// ```
     fn value_string(&self) -> Result<String, SysctlError>;
 
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_doctest_main))]
     /// Sets the value of a sysctl.
     /// Fetches and returns the new value if successful, or returns a
     /// SysctlError on failure.
@@ -138,6 +139,7 @@ pub trait Sysctl {
     /// }
     fn set_value(&self, value: CtlValue) -> Result<CtlValue, SysctlError>;
 
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_doctest_main))]
     /// Sets the value of a sysctl with input as string.
     /// Fetches and returns the new value if successful, or returns a
     /// SysctlError on failure.
@@ -172,6 +174,7 @@ pub trait Sysctl {
     /// ```
     fn flags(&self) -> Result<CtlFlags, SysctlError>;
 
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_doctest_main))]
     /// Returns a Result containing the control metadata for a sysctl.
     ///
     /// Returns a Result containing the CtlInfo struct on success,

--- a/src/unix/ctl.rs
+++ b/src/unix/ctl.rs
@@ -18,6 +18,7 @@ pub struct Ctl {
 impl std::str::FromStr for Ctl {
     type Err = SysctlError;
 
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::redundant_field_names))]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let oid = name2oid(s)?;
 
@@ -145,7 +146,7 @@ impl Sysctl for Ctl {
     }
 
     fn info(&self) -> Result<CtlInfo, SysctlError> {
-        Ok(oidfmt(&self.oid)?)
+        oidfmt(&self.oid)
     }
 }
 

--- a/src/unix/ctl_iter.rs
+++ b/src/unix/ctl_iter.rs
@@ -70,7 +70,7 @@ impl IntoIterator for Ctl {
     type Item = Result<Ctl, SysctlError>;
     type IntoIter = CtlIter;
 
-    fn into_iter(self: Self) -> Self::IntoIter {
+    fn into_iter(self) -> Self::IntoIter {
         CtlIter::below(self)
     }
 }


### PR DESCRIPTION
This PR fixes a few issues reported by `cargo clippy`.

We exclude lints in various places:
  - `needless_doctest_main` so that we don't change the documentation
  - `redundant_field_names` so we don't end up with mixed style struct instantiations

These changes were made on FreeBSD and the test suite passes there. I don't currently have access to Linux or macOS, but could test there later if needed.