### PR TITLE
Fix the build with minimally-specified dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,4 +39,7 @@ task:
     fingerprint_script: cat Cargo.lock
   build_script: cargo build --all && cargo build --examples
   test_script: cargo test --all
+  minver_test_script:
+    - cargo update -Zminimal-versions
+    - cargo check --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://johalun.github.io/sysctl-rs/index.html"
 [dependencies]
 libc = "^0.2.34"
 byteorder = "^1.0.0"
-thiserror = "1"
+thiserror = "1.0.2"
 bitflags = "^1.0"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]


### PR DESCRIPTION
Needs thiserror 1.0.2 or later for #[from]

Check minver in CI.