### PR TITLE
Don't include docs in the package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/johalun/sysctl-rs"
 documentation = "https://johalun.github.io/sysctl-rs/index.html"
+include = ["src/**/*", "LICENSE-MIT", "README.md", "CHANGELOG.md"]
 
 [dependencies]
 libc = "^0.2.34"


### PR DESCRIPTION
This reduces the size of the crate download by 98%, before compression.