### PR TITLE
Update the FreeBSD CI images to currently supported releases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,8 +1,8 @@
 task:
   freebsd_instance:
     matrix:
-      image: freebsd-12-0-release-amd64
-      image: freebsd-11-2-release-amd64
+      image: freebsd-12-2-release-amd64
+      image: freebsd-11-4-release-amd64
   install_script: |
     pkg install -y curl
     curl https://sh.rustup.rs -sSf | sh -s -- -y


### PR DESCRIPTION
This should fix CI's pkg errors