### PR TITLE
Remove debugging println that is visible on FreeBSD

### DIFF
--- a/src/unix/ctl.rs
+++ b/src/unix/ctl.rs
@@ -90,7 +90,6 @@ impl Sysctl for Ctl {
     #[cfg(not(target_os = "macos"))]
     fn set_value_string(&self, value: &str) -> Result<String, SysctlError> {
         let ctl_type = self.value_type()?;
-        println!("type {:?}", ctl_type);
         let _ = match ctl_type {
             CtlType::String => set_oid_value(&self.oid, CtlValue::String(value.to_owned())),
             CtlType::Uint => set_oid_value(


### PR DESCRIPTION
This addresses issue #46 where it seems to be that a `println!` for debugging has been left behind, affecting at least FreeBSD.