### PR TITLE
add iOS as a supported target

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This crate provides a safe interface for reading and writing information to the 
 [![Current Version](https://img.shields.io/crates/v/sysctl.svg)](https://crates.io/crates/sysctl)
 
 
-*FreeBSD, Linux and macOS are supported.*
+*FreeBSD, Linux, macOS and iOS are supported.*
 *Contributions for improvements and other platforms are welcome.*
 
 ### Documentation
@@ -21,11 +21,11 @@ Add to `Cargo.toml`
 sysctl = "0.4.4"
 ```
 
-### macOS
+### macOS/iOS
 
 * Due to limitations in the sysctl(3) API, many of the methods of
-  the `Ctl` take a mutable reference to `self` on macOS.
-* Sysctl descriptions are not available on macOS and Linux.
+  the `Ctl` take a mutable reference to `self` on macOS/iOS.
+* Sysctl descriptions are not available on macOS/iOS and Linux.
 * Some tests failures are ignored, as the respective sysctls do not
   exist on macos.
 

--- a/src/ctl_error.rs
+++ b/src/ctl_error.rs
@@ -7,7 +7,7 @@ pub enum SysctlError {
     NotFound(String),
 
     #[error("no matching type for value")]
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     UnknownType,
 
     #[error("Error extracting value")]

--- a/src/ctl_flags.rs
+++ b/src/ctl_flags.rs
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn ctl_flags() {
         // This sysctl should be read-only.
-        #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+        #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
         let ctl: crate::Ctl = crate::Ctl::new("kern.ostype").unwrap();
         #[cfg(any(target_os = "android", target_os = "linux"))]
         let ctl: crate::Ctl = crate::Ctl::new("kernel.ostype").unwrap();

--- a/src/ctl_value.rs
+++ b/src/ctl_value.rs
@@ -94,7 +94,7 @@ mod tests_linux {
     }
 }
 
-#[cfg(all(test, any(target_os = "freebsd", target_os = "macos")))]
+#[cfg(all(test, any(target_os = "freebsd", target_os = "macos", target_os = "ios")))]
 mod tests_unix {
     use crate::sys;
     use crate::Sysctl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! # Example: Get value
 //! ```
 //! # use sysctl::Sysctl;
-//! #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+//! #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
 //! const CTLNAME: &str = "kern.ostype";
 //! #[cfg(any(target_os = "linux", target_os = "android"))]
 //! const CTLNAME: &str = "kernel.ostype";
@@ -34,9 +34,9 @@
 //!     stathz: libc::c_int, /* statistics clock frequency */
 //!     profhz: libc::c_int, /* profiling clock frequency */
 //! }
-//! # #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+//! # #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
 //! let val: Box<ClockInfo> = sysctl::Ctl::new("kern.clockrate").unwrap().value_as().unwrap();
-//! # #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+//! # #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
 //! println!("{:?}", val);
 //! ```
 
@@ -53,7 +53,7 @@ extern crate walkdir;
 #[path = "linux/mod.rs"]
 mod sys;
 
-#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
 #[path = "unix/mod.rs"]
 mod sys;
 

--- a/src/unix/ctl.rs
+++ b/src/unix/ctl.rs
@@ -35,13 +35,13 @@ impl Sysctl for Ctl {
         oid2name(&self.oid)
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     fn value_type(&self) -> Result<CtlType, SysctlError> {
         let info = oidfmt(&self.oid)?;
         Ok(info.ctl_type)
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn value_type(&self) -> Result<CtlType, SysctlError> {
         let info = oidfmt(&self.oid)?;
 
@@ -57,28 +57,28 @@ impl Sysctl for Ctl {
         })
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     fn description(&self) -> Result<String, SysctlError> {
         oid2description(&self.oid)
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn description(&self) -> Result<String, SysctlError> {
         Ok("[N/A]".to_string())
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     fn value(&self) -> Result<CtlValue, SysctlError> {
         value_oid(&self.oid)
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn value(&self) -> Result<CtlValue, SysctlError> {
         let mut oid = self.oid.clone();
         value_oid(&mut oid)
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     fn value_as<T>(&self) -> Result<Box<T>, SysctlError> {
         value_oid_as::<T>(&self.oid)
     }
@@ -87,24 +87,24 @@ impl Sysctl for Ctl {
         self.value().map(|v| format!("{}", v))
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn value_as<T>(&self) -> Result<Box<T>, SysctlError> {
         let mut oid = self.oid.clone();
         value_oid_as::<T>(&mut oid)
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     fn set_value(&self, value: CtlValue) -> Result<CtlValue, SysctlError> {
         set_oid_value(&self.oid, value)
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn set_value(&self, value: CtlValue) -> Result<CtlValue, SysctlError> {
         let mut oid = self.oid.clone();
         set_oid_value(&mut oid, value)
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     fn set_value_string(&self, value: &str) -> Result<String, SysctlError> {
         let ctl_type = self.value_type()?;
         let _ = match ctl_type {
@@ -130,7 +130,7 @@ impl Sysctl for Ctl {
         self.value_string()
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn set_value_string(&self, value: &str) -> Result<String, SysctlError> {
         let ctl_type = self.value_type()?;
         let mut oid = self.oid.clone();
@@ -187,7 +187,7 @@ mod tests {
         #[cfg(target_os = "freebsd")]
         assert_eq!(descp, "Operating system type");
 
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
         assert_eq!(descp, "[N/A]");
     }
 }

--- a/src/unix/funcs.rs
+++ b/src/unix/funcs.rs
@@ -40,7 +40,7 @@ pub fn name2oid(name: &str) -> Result<Vec<libc::c_int>, SysctlError> {
     Ok(res)
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 pub fn oidfmt(oid: &[libc::c_int]) -> Result<CtlInfo, SysctlError> {
     // Request command for type info
     let mut qoid: Vec<libc::c_int> = vec![0, 4];
@@ -85,7 +85,7 @@ pub fn oidfmt(oid: &[libc::c_int]) -> Result<CtlInfo, SysctlError> {
     Ok(s)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub fn oidfmt(oid: &[libc::c_int]) -> Result<CtlInfo, SysctlError> {
     // Request command for type info
     let mut qoid: Vec<libc::c_int> = vec![0, 4];
@@ -136,7 +136,7 @@ pub fn oidfmt(oid: &[libc::c_int]) -> Result<CtlInfo, SysctlError> {
     Ok(s)
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 pub fn value_oid(oid: &[i32]) -> Result<CtlValue, SysctlError> {
     let info: CtlInfo = oidfmt(&oid)?;
 
@@ -225,7 +225,7 @@ pub fn value_oid(oid: &[i32]) -> Result<CtlValue, SysctlError> {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub fn value_oid(oid: &mut Vec<i32>) -> Result<CtlValue, SysctlError> {
     let info: CtlInfo = oidfmt(&oid)?;
 
@@ -313,7 +313,7 @@ pub fn value_oid(oid: &mut Vec<i32>) -> Result<CtlValue, SysctlError> {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 pub fn value_oid_as<T>(oid: &[i32]) -> Result<Box<T>, SysctlError> {
     let val_enum = value_oid(oid)?;
 
@@ -357,7 +357,7 @@ pub fn value_oid_as<T>(oid: &[i32]) -> Result<Box<T>, SysctlError> {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub fn value_oid_as<T>(oid: &mut Vec<i32>) -> Result<Box<T>, SysctlError> {
     let val_enum = value_oid(oid)?;
 
@@ -429,7 +429,7 @@ fn value_to_bytes(value: CtlValue) -> Result<Vec<u8>, SysctlError> {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 pub fn set_oid_value(oid: &[libc::c_int], value: CtlValue) -> Result<CtlValue, SysctlError> {
     let info: CtlInfo = oidfmt(&oid)?;
 
@@ -465,7 +465,7 @@ pub fn set_oid_value(oid: &[libc::c_int], value: CtlValue) -> Result<CtlValue, S
     self::value_oid(oid)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub fn set_oid_value(oid: &mut Vec<libc::c_int>, value: CtlValue) -> Result<CtlValue, SysctlError> {
     let info: CtlInfo = oidfmt(&oid)?;
 
@@ -515,7 +515,7 @@ pub fn set_oid_value(oid: &mut Vec<libc::c_int>, value: CtlValue) -> Result<CtlV
     self::value_oid(oid)
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 pub fn oid2description(oid: &[libc::c_int]) -> Result<String, SysctlError> {
     // Request command for description
     let mut qoid: Vec<libc::c_int> = vec![0, 5];
@@ -545,7 +545,7 @@ pub fn oid2description(oid: &[libc::c_int]) -> Result<String, SysctlError> {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 pub fn oid2name(oid: &[libc::c_int]) -> Result<String, SysctlError> {
     // Request command for name
     let mut qoid: Vec<libc::c_int> = vec![0, 1];
@@ -575,7 +575,7 @@ pub fn oid2name(oid: &[libc::c_int]) -> Result<String, SysctlError> {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub fn oid2name(oid: &Vec<libc::c_int>) -> Result<String, SysctlError> {
     // Request command for name
     let mut qoid: Vec<libc::c_int> = vec![0, 1];
@@ -605,7 +605,7 @@ pub fn oid2name(oid: &Vec<libc::c_int>) -> Result<String, SysctlError> {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 pub fn next_oid(oid: &[libc::c_int]) -> Result<Option<Vec<libc::c_int>>, SysctlError> {
     // Request command for next oid
     let mut qoid: Vec<libc::c_int> = vec![0, 2];
@@ -644,7 +644,7 @@ pub fn next_oid(oid: &[libc::c_int]) -> Result<Option<Vec<libc::c_int>>, SysctlE
     Ok(Some(res))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub fn next_oid(oid: &Vec<libc::c_int>) -> Result<Option<Vec<libc::c_int>>, SysctlError> {
     // Request command for next oid
     let mut qoid: Vec<libc::c_int> = vec![0, 2];
@@ -751,7 +751,7 @@ mod tests_freebsd {
     }
 }
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(all(test, any(target_os = "macos", target_os = "ios")))]
 mod tests_macos {
     #[test]
     fn ctl_mib() {


### PR DESCRIPTION
Add iOS as a target, which shares the same code base as Mac OS.