### PR TITLE
implement variant of Ctl that strictly uses sysctlbyname

### DIFF
--- a/examples/value_oid_as.rs
+++ b/examples/value_oid_as.rs
@@ -21,7 +21,7 @@ struct ClockInfo {
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 fn main() {
     let oid: Vec<i32> = vec![libc::CTL_KERN, libc::KERN_CLOCKRATE];
-    let val: Box<ClockInfo> = sysctl::Ctl { oid }.value_as().expect("could not get value");
+    let val: Box<ClockInfo> = sysctl::Ctl::Oid(oid).value_as().expect("could not get value");
     println!("{:?}", val);
 }
 

--- a/src/ctl_error.rs
+++ b/src/ctl_error.rs
@@ -41,4 +41,7 @@ pub enum SysctlError {
 
     #[error("Error reading C String: String was not NUL-terminated.")]
     InvalidCStr(#[from] std::ffi::FromBytesWithNulError),
+
+    #[error("Error Rust string contains nul bytes")]
+    InvalidCString(#[from] std::ffi::NulError),
 }

--- a/src/linux/ctl.rs
+++ b/src/linux/ctl.rs
@@ -40,6 +40,10 @@ impl Sysctl for Ctl {
         Ctl::from_str(name)
     }
 
+    fn new_with_type(name: &str, _ctl_type: CtlType, _fmt: &str) -> Result<Self, SysctlError> {
+        Ctl::from_str(name)
+    }
+
     fn name(&self) -> Result<String, SysctlError> {
         Ok(self.name.clone())
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -34,6 +34,33 @@ pub trait Sysctl {
     where
         Self: std::marker::Sized;
 
+    /// Construct a Ctl from the name, type and format.
+    ///
+    /// Returns a result containing the struct Ctl on success or a SysctlError
+    /// on failure.
+    ///
+    /// # Example
+    /// ```
+    /// # use sysctl::Sysctl;
+    /// #
+    /// let ctl = sysctl::Ctl::new_with_type("kern.ostype", CtlType::String, "");
+    /// ```
+    ///
+    /// If the sysctl does not exist, `Err(SysctlError::NotFound)` is returned.
+    /// ```
+    /// # use sysctl::Sysctl;
+    /// #
+    /// let ctl = sysctl::Ctl::new_with_type("this.sysctl.does.not.exist", CtlType::String, "");
+    /// match ctl {
+    ///     Err(sysctl::SysctlError::NotFound(_)) => (),
+    ///     Err(e) => panic!(format!("Wrong error type returned: {:?}", e)),
+    ///     Ok(_) => panic!("Nonexistent sysctl seems to exist"),
+    /// }
+    /// ```
+    fn new_with_type(name: &str, ctl_type: CtlType, fmt: &str) -> Result<Self, SysctlError>
+    where
+        Self: std::marker::Sized;
+
     /// Returns a result containing the sysctl name on success, or a
     /// SysctlError on failure.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -41,19 +41,19 @@ pub trait Sysctl {
     ///
     /// # Example
     /// ```
-    /// # use sysctl::Sysctl;
+    /// # use sysctl::{CtlType, Sysctl};
     /// #
     /// let ctl = sysctl::Ctl::new_with_type("kern.ostype", CtlType::String, "");
     /// ```
     ///
     /// If the sysctl does not exist, `Err(SysctlError::NotFound)` is returned.
     /// ```
-    /// # use sysctl::Sysctl;
+    /// # use sysctl::{CtlType, Sysctl};
     /// #
     /// let ctl = sysctl::Ctl::new_with_type("this.sysctl.does.not.exist", CtlType::String, "");
     /// match ctl {
     ///     Err(sysctl::SysctlError::NotFound(_)) => (),
-    ///     Err(e) => panic!(format!("Wrong error type returned: {:?}", e)),
+    ///     Err(e) => panic!("Wrong error type returned: {:?}", e),
     ///     Ok(_) => panic!("Nonexistent sysctl seems to exist"),
     /// }
     /// ```

--- a/src/unix/ctl.rs
+++ b/src/unix/ctl.rs
@@ -182,7 +182,7 @@ impl Sysctl for Ctl {
         let oid = self.oid().ok_or(SysctlError::MissingImplementation)?;
         let ctl_type = self.value_type()?;
         let _ = match ctl_type {
-            CtlType::String => set_oid_value(self.oid(), CtlValue::String(value.to_owned())),
+            CtlType::String => set_oid_value(oid, CtlValue::String(value.to_owned())),
             CtlType::Uint => set_oid_value(
                 oid,
                 CtlValue::Uint(value.parse::<u32>().map_err(|_| SysctlError::ParseError)?),

--- a/src/unix/ctl.rs
+++ b/src/unix/ctl.rs
@@ -48,6 +48,8 @@ impl Sysctl for Ctl {
 
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn new_with_type(name: &str, ctl_type: CtlType, fmt: &str) -> Result<Self, SysctlError> {
+        let _ = name2oid(name)?;
+
         Ok(Ctl::Name(name.to_string(), ctl_type, fmt.to_string()))
     }
 

--- a/src/unix/ctl.rs
+++ b/src/unix/ctl.rs
@@ -67,7 +67,7 @@ impl Sysctl for Ctl {
                 let info = oidfmt(oid)?;
                 Ok(info.ctl_type)
             }
-            Ctl::Name(_, ctl_type) => {
+            Ctl::Name(_, ctl_type, _) => {
                 Ok(*ctl_type)
             }
         }
@@ -182,7 +182,7 @@ impl Sysctl for Ctl {
         let oid = self.oid().ok_or(SysctlError::MissingImplementation)?;
         let ctl_type = self.value_type()?;
         let _ = match ctl_type {
-            CtlType::String => set_oid_value(&self.oid, CtlValue::String(value.to_owned())),
+            CtlType::String => set_oid_value(self.oid(), CtlValue::String(value.to_owned())),
             CtlType::Uint => set_oid_value(
                 oid,
                 CtlValue::Uint(value.parse::<u32>().map_err(|_| SysctlError::ParseError)?),

--- a/src/unix/ctl_iter.rs
+++ b/src/unix/ctl_iter.rs
@@ -17,8 +17,8 @@ impl CtlIter {
     /// Return an iterator over the complete sysctl tree.
     pub fn root() -> Self {
         CtlIter {
-            base: Ctl { oid: vec![] },
-            current: Ctl { oid: vec![1] },
+            base: Ctl::Oid(vec![]),
+            current: Ctl::Oid(vec![1]),
         }
     }
 
@@ -35,16 +35,16 @@ impl Iterator for CtlIter {
     type Item = Result<Ctl, SysctlError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let oid = match next_oid(&self.current.oid) {
+        let oid = match next_oid(self.current.oid()?) {
             Ok(Some(o)) => o,
             Err(e) => return Some(Err(e)),
             Ok(None) => return None,
         };
 
         // We continue iterating as long as the oid starts with the base
-        let cont = oid.starts_with(&self.base.oid);
+        let cont = oid.starts_with(self.base.oid()?);
 
-        self.current = Ctl { oid };
+        self.current = Ctl::Oid(oid);
 
         match cont {
             true => Some(Ok(self.current.clone())),

--- a/src/unix/funcs.rs
+++ b/src/unix/funcs.rs
@@ -868,7 +868,7 @@ mod tests {
 
         assert_eq!(name, "kern.osrevision");
 
-        let ctl = crate::Ctl { oid };
+        let ctl = crate::Ctl::Oid(oid);
         let name = ctl
             .name()
             .expect("Could not get name of kern.osrevision sysctl.");

--- a/src/unix/funcs.rs
+++ b/src/unix/funcs.rs
@@ -6,6 +6,7 @@ use ctl_error::*;
 use ctl_info::*;
 use ctl_type::*;
 use ctl_value::*;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 use std::ffi::CString;
 
 #[cfg(target_os = "freebsd")]

--- a/src/unix/funcs.rs
+++ b/src/unix/funcs.rs
@@ -6,6 +6,7 @@ use ctl_error::*;
 use ctl_info::*;
 use ctl_type::*;
 use ctl_value::*;
+use std::ffi::CString;
 
 #[cfg(target_os = "freebsd")]
 use temperature::*;
@@ -401,6 +402,131 @@ pub fn value_oid_as<T>(oid: &mut Vec<i32>) -> Result<Box<T>, SysctlError> {
     }
 }
 
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub fn value_name(name: &str, ctl_type: CtlType, fmt: &str) -> Result<CtlValue, SysctlError> {
+    let name = CString::new(name)?;
+
+    // First get size of value in bytes
+    let mut val_len = 0;
+    let ret = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            std::ptr::null_mut(),
+            &mut val_len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret < 0 {
+        return Err(SysctlError::IoError(std::io::Error::last_os_error()));
+    }
+
+    // If the length reported is shorter than the type we will convert it into,
+    // byteorder::LittleEndian::read_* will panic. Therefore, expand the value length to at
+    // Least the size of the value.
+    let val_minsize = std::cmp::max(val_len, ctl_type.min_type_size());
+
+    // Then get value
+    let mut val: Vec<libc::c_uchar> = vec![0; val_minsize];
+    let mut new_val_len = val_len;
+    let ret = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            val.as_mut_ptr() as *mut libc::c_void,
+            &mut new_val_len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret < 0 {
+        return Err(SysctlError::IoError(std::io::Error::last_os_error()));
+    }
+
+    // Confirm that we did not read out of bounds
+    assert!(new_val_len <= val_len);
+    // The call can sometimes return bytes that are smaller than initially indicated, so it should
+    // be safe to truncate it.  See a similar approach in golang module:
+    // https://github.com/golang/sys/blob/43e60d72a8e2bd92ee98319ba9a384a0e9837c08/unix/syscall_bsd.go#L545-L548
+    if new_val_len < val_len {
+        val.truncate(new_val_len);
+    }
+
+    // Wrap in Enum and return
+    match ctl_type {
+        CtlType::None => Ok(CtlValue::None),
+        CtlType::Node => Ok(CtlValue::Node(val)),
+        CtlType::Int => match fmt {
+            "I" => Ok(CtlValue::Int(byteorder::LittleEndian::read_i32(&val))),
+            "IU" => Ok(CtlValue::Uint(byteorder::LittleEndian::read_u32(&val))),
+            "L" => Ok(CtlValue::Long(byteorder::LittleEndian::read_i64(&val))),
+            "LU" => Ok(CtlValue::Ulong(byteorder::LittleEndian::read_u64(&val))),
+            _ => Ok(CtlValue::None),
+        }
+        CtlType::String => match val.len() {
+            0 => Ok(CtlValue::String("".to_string())),
+            l => std::str::from_utf8(&val[..l - 1])
+                .map_err(SysctlError::Utf8Error)
+                .map(|s| CtlValue::String(s.into())),
+        },
+        CtlType::S64 => Ok(CtlValue::S64(byteorder::LittleEndian::read_i64(&val))),
+        CtlType::Struct => Ok(CtlValue::Struct(val)),
+        CtlType::Uint => Ok(CtlValue::Uint(byteorder::LittleEndian::read_u32(&val))),
+        CtlType::Long => Ok(CtlValue::Long(byteorder::LittleEndian::read_i64(&val))),
+        CtlType::Ulong => Ok(CtlValue::Ulong(byteorder::LittleEndian::read_u64(&val))),
+        CtlType::U64 => Ok(CtlValue::U64(byteorder::LittleEndian::read_u64(&val))),
+        CtlType::U8 => Ok(CtlValue::U8(val[0])),
+        CtlType::U16 => Ok(CtlValue::U16(byteorder::LittleEndian::read_u16(&val))),
+        CtlType::S8 => Ok(CtlValue::S8(val[0] as i8)),
+        CtlType::S16 => Ok(CtlValue::S16(byteorder::LittleEndian::read_i16(&val))),
+        CtlType::S32 => Ok(CtlValue::S32(byteorder::LittleEndian::read_i32(&val))),
+        CtlType::U32 => Ok(CtlValue::U32(byteorder::LittleEndian::read_u32(&val))),
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub fn value_name_as<T>(name: &str, ctl_type: CtlType, fmt: &str) -> Result<Box<T>, SysctlError> {
+    let val_enum = value_name(name, ctl_type, fmt)?;
+
+    // Some structs are apparently reported as Node so this check is invalid..
+    // let ctl_type = CtlType::from(&val_enum);
+    // assert_eq!(CtlType::Struct, ctl_type, "Error type is not struct/opaque");
+
+    // TODO: refactor this when we have better clue to what's going on
+    if let CtlValue::Struct(val) = val_enum {
+        // Make sure we got correct data size
+        assert_eq!(
+            std::mem::size_of::<T>(),
+            val.len(),
+            "Error memory size mismatch. Size of struct {}, size of data retrieved {}.",
+            std::mem::size_of::<T>(),
+            val.len()
+        );
+
+        // val is Vec<u8>
+        let val_array: Box<[u8]> = val.into_boxed_slice();
+        let val_raw: *mut T = Box::into_raw(val_array) as *mut T;
+        let val_box: Box<T> = unsafe { Box::from_raw(val_raw) };
+        Ok(val_box)
+    } else if let CtlValue::Node(val) = val_enum {
+        // Make sure we got correct data size
+        assert_eq!(
+            std::mem::size_of::<T>(),
+            val.len(),
+            "Error memory size mismatch. Size of struct {}, size of data retrieved {}.",
+            std::mem::size_of::<T>(),
+            val.len()
+        );
+
+        // val is Vec<u8>
+        let val_array: Box<[u8]> = val.into_boxed_slice();
+        let val_raw: *mut T = Box::into_raw(val_array) as *mut T;
+        let val_box: Box<T> = unsafe { Box::from_raw(val_raw) };
+        Ok(val_box)
+    } else {
+        Err(SysctlError::ExtractionError)
+    }
+}
+
 fn value_to_bytes(value: CtlValue) -> Result<Vec<u8>, SysctlError> {
     // TODO rest of the types
     match value {
@@ -513,6 +639,54 @@ pub fn set_oid_value(oid: &mut Vec<libc::c_int>, value: CtlValue) -> Result<CtlV
 
     // Get the new value and return for confirmation
     self::value_oid(oid)
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub fn set_name_value(
+    name: &str,
+    info_ctl_type: CtlType,
+    fmt: &str,
+    value: CtlValue,
+) -> Result<CtlValue, SysctlError> {
+    let c_name = CString::new(name)?;
+    let ctl_type = CtlType::from(&value);
+
+    // Get the correct ctl type based on the format string
+    let info_ctl_type = match info_ctl_type {
+        CtlType::Int => match fmt {
+            "I" => CtlType::Int,
+            "IU" => CtlType::Uint,
+            "L" => CtlType::Long,
+            "LU" => CtlType::Ulong,
+            _ => return Err(SysctlError::MissingImplementation),
+        }
+        ctl_type => ctl_type,
+    };
+
+    assert_eq!(
+        info_ctl_type, ctl_type,
+        "Error type mismatch. Type given {:?}, sysctl type: {:?}",
+        ctl_type, info_ctl_type
+    );
+
+    let bytes = value_to_bytes(value)?;
+
+    // Set value
+    let ret = unsafe {
+        libc::sysctlbyname(
+            c_name.as_ptr(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            bytes.as_ptr() as *mut libc::c_void,
+            bytes.len(),
+        )
+    };
+    if ret < 0 {
+        return Err(SysctlError::IoError(std::io::Error::last_os_error()));
+    }
+
+    // Get the new value and return for confirmation
+    self::value_name(name, ctl_type, fmt)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]


### PR DESCRIPTION
sysctl-rs makes extensive use of sysctl oidfmt to look up the type and format of sysctls. Unfortunately, this is not allowed on non-jailbroken iOS as any such calls return `-EPERM`. Instead, we should be using `sysctlbyname` on iOS, which means that we are way more restricted since we cannot look up the type or format, and as such the user will have to provide these for full iOS support. In addition, the original implementation does work on jailbroken iOS, so we want to keep that option available (e.g. you could first try using `Ctl::new()` and then fallback to `Ctl::new_with_type()` to support both).

This PR changes the following things:
 - `Ctl` in `unix.rs` is now an enum that either contains the oid or the name + type + format string.
 - `Ctl` in `unix.rs` implements `oid()` to return a reference to the oid, in case the underlying Oid variant is used. This is a breaking change (requires a version bump to 0.5.0), as `Ctl` used to contain a `pub oid` that now no longer exists.
 - The `Sysctl` trait is extended with a `new_with_type()` function to construct a `Ctl` from a name, type and format string. On other platforms (i.e. not MacOS or iOS), this function will simply ignore the type and format string and instead fallback to the original oid implementation as that works fine.
 - To get/set the value for the named `Ctl` variant, there are now functions that use `sysctlbyname` + the supplied type and format string instead of `sysctl` + `oidfmt`internally.
 - `CtlIter` still uses oids, but that is fine. As on iOS this should just fail gracefully. That does mean that you cannot iterate over the available sysctls on a non-jailbroken iOS.