### PR TITLE
Add accessor methods for destructuring CtlValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [ Unreleased ] - ReleaseDate
+### Added
+
+- Added accessor methods to destructure `CtlValue`.
+
 ## [0.5.2] - 2022-08-16
 ### Changed
 - CI minimum version test failing. Adjust versions to fix.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ targets = [
 ]
 
 [dependencies]
+enum-as-inner = "0.5.1"
 libc = "^0.2.34"
 byteorder = "^1.4"
 thiserror = "^1.0.32"

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -28,16 +28,8 @@ fn main() {
     let d = ctl.description().expect("could not get sysctl description");
     println!("Description: {:?}", d);
 
-    let val_enum = ctl.value().expect("could not get sysctl value");
-    println!("ClockInfo raw data (byte array): {:?}", val_enum);
-
-    if let sysctl::CtlValue::Struct(val) = val_enum {
-        // Make sure we got correct data size
-        assert_eq!(std::mem::size_of::<ClockInfo>(), val.len());
-        let val_ptr: *const u8 = val.as_ptr();
-        let struct_ptr: *const ClockInfo = val_ptr as *const ClockInfo;
-        let struct_ref: &ClockInfo = unsafe { &*struct_ptr };
-        println!("{:?}", struct_ref);
+    if let Ok(s) = ctl.value_as::<ClockInfo>() {
+        println!("{:?}", s);
     }
 }
 

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -24,16 +24,13 @@ fn main() {
 
     let val_enum = ctl.value().expect("could not get value");
 
-    if let sysctl::CtlValue::Temperature(val) = val_enum {
-        println!(
-            "Temperature: {:.2}K, {:.2}F, {:.2}C",
-            val.kelvin(),
-            val.fahrenheit(),
-            val.celsius()
-        );
-    } else {
-        panic!("Error, not a temperature ctl!")
-    }
+    let temp = val_enum.as_temperature().unwrap();
+    println!(
+        "Temperature: {:.2}K, {:.2}F, {:.2}C",
+        temp.kelvin(),
+        temp.fahrenheit(),
+        temp.celsius()
+    );
 }
 
 #[cfg(not(target_os = "freebsd"))]

--- a/src/ctl_value.rs
+++ b/src/ctl_value.rs
@@ -2,21 +2,24 @@
 
 #[cfg(target_os = "freebsd")]
 use temperature::Temperature;
+use enum_as_inner::EnumAsInner;
 
 /// An Enum that holds all values returned by sysctl calls.
-/// Extract inner value with `if let` or `match`.
+/// Extract inner value with accessors like `as_int()`.
 ///
 /// # Example
 ///
 /// ```
 /// # use sysctl::Sysctl;
 /// if let Ok(ctl) = sysctl::Ctl::new("kern.osrevision") {
-///     if let Ok(sysctl::CtlValue::Int(val)) = ctl.value() {
-///         println!("Value: {}", val);
+///     if let Ok(r) = ctl.value() {
+///         if let Some(val) = r.as_int() {
+///             println!("Value: {}", val);
+///         }
 ///     }
 /// }
 /// ```
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, EnumAsInner, PartialEq, PartialOrd)]
 pub enum CtlValue {
     None,
     Node(Vec<u8>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;
+extern crate enum_as_inner;
 extern crate libc;
 extern crate thiserror;
 

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -14,14 +14,12 @@ use std::f32;
 /// ```
 /// # use sysctl::Sysctl;
 /// if let Ok(ctl) = sysctl::Ctl::new("dev.cpu.0.temperature") {
-///     if let Ok(sysctl::CtlValue::Temperature(val)) = ctl.value() {
-///         println!("Temperature: {:.2}K, {:.2}F, {:.2}C",
-///                   val.kelvin(),
-///                   val.fahrenheit(),
-///                   val.celsius());
-///     } else {
-///         panic!("Error, not a temperature ctl!")
-///     }
+///     let val = ctl.value().unwrap();
+///     let temp = val.as_temperature().unwrap();
+///     println!("Temperature: {:.2}K, {:.2}F, {:.2}C",
+///               temp.kelvin(),
+///               temp.fahrenheit(),
+///               temp.celsius());
 /// }
 /// ```
 /// Not available on MacOS
@@ -92,13 +90,10 @@ mod tests_freebsd {
             .expect("Error parsing value to byte array");
 
         let t = super::temperature(&info, &val).unwrap();
-        if let crate::CtlValue::Temperature(tt) = t {
-            assert!(tt.kelvin() - 333.0 < 0.1);
-            assert!(tt.celsius() - 59.85 < 0.1);
-            assert!(tt.fahrenheit() - 139.73 < 0.1);
-        } else {
-            assert!(false);
-        }
+        let tt = t.as_temperature().unwrap();
+        assert!(tt.kelvin() - 333.0 < 0.1);
+        assert!(tt.celsius() - 59.85 < 0.1);
+        assert!(tt.fahrenheit() - 139.73 < 0.1);
     }
 
     #[test]
@@ -114,10 +109,7 @@ mod tests_freebsd {
             .expect("Error parsing value to byte array");
 
         let t = super::temperature(&info, &val).unwrap();
-        if let crate::CtlValue::Temperature(tt) = t {
-            assert!(tt.kelvin() - 333.0 < 0.1);
-        } else {
-            assert!(false);
-        }
+        let tt = t.as_temperature().unwrap();
+        assert!(tt.kelvin() - 333.0 < 0.1);
     }
 }


### PR DESCRIPTION
For example, these methods shorten
```rust
if let CtlValue::Temperature(t) = value {
    ...
}
```
into
```rust
let t = value.as_temperature().unwrap();
```