### PR TITLE
Update enum-as-inner to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+- Updated enum-as-inner to 0.6.0, to remove dependencies on both syn-1 and syn-2.
+
 ## [0.5.4] - 2022-12-09
 ### Changed
 - Bumped byteorder crate to 1.4.3 due to failing tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ targets = [
 ]
 
 [dependencies]
-enum-as-inner = "0.5.1"
+enum-as-inner = "0.6.0"
 libc = "^0.2.34"
 byteorder = "^1.4.3"
 thiserror = "^1.0.32"


### PR DESCRIPTION
This elminates a double dependency on both syn-1 and syn-2