### PR TITLE
Update bitflags to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ enum-as-inner = "0.6.0"
 libc = "^0.2.34"
 byteorder = "^1.4.3"
 thiserror = "^1.0.32"
-bitflags = "^1.3"
+bitflags = "^2"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 walkdir = "^2.2.8"

--- a/src/ctl_flags.rs
+++ b/src/ctl_flags.rs
@@ -11,7 +11,7 @@ bitflags! {
         /// Allow writes to the variable
         const WR = CTLFLAG_WR;
 
-        const RW = Self::RD.bits | Self::WR.bits;
+        const RW = Self::RD.bits() | Self::WR.bits();
 
         /// This sysctl is not active yet
         const DORMANT = CTLFLAG_DORMANT;
@@ -38,10 +38,10 @@ bitflags! {
         const TUN = CTLFLAG_TUN;
 
         /// Readable tunable
-        const RDTUN = Self::RD.bits | Self::TUN.bits;
+        const RDTUN = Self::RD.bits() | Self::TUN.bits();
 
         /// Readable and writeable tunable
-        const RWTUN = Self::RW.bits | Self::TUN.bits;
+        const RWTUN = Self::RW.bits() | Self::TUN.bits();
 
         /// Handler is MP safe
         const MPSAFE = CTLFLAG_MPSAFE;
@@ -65,7 +65,7 @@ bitflags! {
         const NOFETCH = CTLFLAG_NOFETCH;
 
         /// Can be read and written in capability mode
-        const CAPRW = Self::CAPRD.bits | Self::CAPWR.bits;
+        const CAPRW = Self::CAPRD.bits() | Self::CAPWR.bits();
     }
 }
 


### PR DESCRIPTION
From https://github.com/bitflags/bitflags/releases/tag/2.0.0 the only breaking change appears to be on .bits