### PR TITLE
During CI, use -Zdirect-minimal-versions instead of -Zminimal-versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,6 +58,6 @@ test_task:
     fingerprint_script:
       - rustc --version
   minver_test_script:
-    - cargo update -Zminimal-versions
+    - cargo update -Zdirect-minimal-versions
     - cargo check --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index


### PR DESCRIPTION
Because enum-as-inner no longer builds with -Zminimal-versions on recent nightlies.