### PR TITLE
Add support for tvOS and visionOS platforms

### DIFF
--- a/src/ctl_error.rs
+++ b/src/ctl_error.rs
@@ -7,7 +7,7 @@ pub enum SysctlError {
     NotFound(String),
 
     #[error("no matching type for value")]
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
     UnknownType,
 
     #[error("Error extracting value")]

--- a/src/ctl_flags.rs
+++ b/src/ctl_flags.rs
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn ctl_flags() {
         // This sysctl should be read-only.
-        #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
+        #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
         let ctl: crate::Ctl = crate::Ctl::new("kern.ostype").unwrap();
         #[cfg(any(target_os = "android", target_os = "linux"))]
         let ctl: crate::Ctl = crate::Ctl::new("kernel.ostype").unwrap();

--- a/src/ctl_type.rs
+++ b/src/ctl_type.rs
@@ -68,7 +68,6 @@ impl std::convert::From<&CtlValue> for CtlType {
         }
     }
 }
-
 impl std::convert::From<CtlValue> for CtlType {
     fn from(t: CtlValue) -> Self {
         Self::from(&t)
@@ -100,3 +99,4 @@ impl CtlType {
         }
     }
 }
+

--- a/src/ctl_value.rs
+++ b/src/ctl_value.rs
@@ -97,7 +97,7 @@ mod tests_linux {
     }
 }
 
-#[cfg(all(test, any(target_os = "freebsd", target_os = "macos", target_os = "ios")))]
+#[cfg(all(test, any(target_os = "freebsd", target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
 mod tests_unix {
     use crate::sys;
     use crate::Sysctl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! # Example: Get value
 //! ```
 //! # use sysctl::Sysctl;
-//! #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+//! #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos", target_os = "freebsd"))]
 //! const CTLNAME: &str = "kern.ostype";
 //! #[cfg(any(target_os = "linux", target_os = "android"))]
 //! const CTLNAME: &str = "kernel.ostype";
@@ -34,9 +34,9 @@
 //!     stathz: libc::c_int, /* statistics clock frequency */
 //!     profhz: libc::c_int, /* profiling clock frequency */
 //! }
-//! # #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+//! # #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos", target_os = "freebsd"))]
 //! let val: Box<ClockInfo> = sysctl::Ctl::new("kern.clockrate").unwrap().value_as().unwrap();
-//! # #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+//! # #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos", target_os = "freebsd"))]
 //! println!("{:?}", val);
 //! ```
 
@@ -54,7 +54,7 @@ extern crate walkdir;
 #[path = "linux/mod.rs"]
 mod sys;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos", target_os = "freebsd"))]
 #[path = "unix/mod.rs"]
 mod sys;
 

--- a/src/unix/ctl.rs
+++ b/src/unix/ctl.rs
@@ -41,12 +41,12 @@ impl Sysctl for Ctl {
         Ctl::from_str(name)
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
     fn new_with_type(name: &str, _ctl_type: CtlType, _fmt: &str) -> Result<Self, SysctlError> {
         Ctl::from_str(name)
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
     fn new_with_type(name: &str, ctl_type: CtlType, fmt: &str) -> Result<Self, SysctlError> {
         let _ = name2oid(name)?;
 
@@ -60,7 +60,7 @@ impl Sysctl for Ctl {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
     fn value_type(&self) -> Result<CtlType, SysctlError> {
         match self {
             Ctl::Oid(oid) => {
@@ -73,7 +73,7 @@ impl Sysctl for Ctl {
         }
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
     fn value_type(&self) -> Result<CtlType, SysctlError> {
         match self {
             Ctl::Oid(oid) => {
@@ -105,24 +105,24 @@ impl Sysctl for Ctl {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
     fn description(&self) -> Result<String, SysctlError> {
         let oid = self.oid().ok_or(SysctlError::MissingImplementation)?;
         oid2description(oid)
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
     fn description(&self) -> Result<String, SysctlError> {
         Ok("[N/A]".to_string())
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
     fn value(&self) -> Result<CtlValue, SysctlError> {
         let oid = self.oid().ok_or(SysctlError::MissingImplementation)?;
         value_oid(oid)
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
     fn value(&self) -> Result<CtlValue, SysctlError> {
         match self {
             Ctl::Oid(oid) => {
@@ -135,7 +135,7 @@ impl Sysctl for Ctl {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
     fn value_as<T>(&self) -> Result<Box<T>, SysctlError> {
         let oid = self.oid().ok_or(SysctlError::MissingImplementation)?;
         value_oid_as::<T>(oid)
@@ -145,7 +145,7 @@ impl Sysctl for Ctl {
         self.value().map(|v| format!("{}", v))
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
     fn value_as<T>(&self) -> Result<Box<T>, SysctlError> {
         match self {
             Ctl::Oid(oid) => {
@@ -158,13 +158,13 @@ impl Sysctl for Ctl {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
     fn set_value(&self, value: CtlValue) -> Result<CtlValue, SysctlError> {
         let oid = self.oid().ok_or(SysctlError::MissingImplementation)?;
         set_oid_value(&oid, value)
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
     fn set_value(&self, value: CtlValue) -> Result<CtlValue, SysctlError> {
         match self {
             Ctl::Oid(oid) => {
@@ -177,7 +177,7 @@ impl Sysctl for Ctl {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
     fn set_value_string(&self, value: &str) -> Result<String, SysctlError> {
         let oid = self.oid().ok_or(SysctlError::MissingImplementation)?;
         let ctl_type = self.value_type()?;
@@ -204,7 +204,7 @@ impl Sysctl for Ctl {
         self.value_string()
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
     fn set_value_string(&self, value: &str) -> Result<String, SysctlError> {
         let ctl_type = self.value_type()?;
 
@@ -303,7 +303,7 @@ mod tests {
         #[cfg(target_os = "freebsd")]
         assert_eq!(descp, "Operating system type");
 
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos", target_os = "linux"))]
         assert_eq!(descp, "[N/A]");
     }
 }

--- a/src/unix/funcs.rs
+++ b/src/unix/funcs.rs
@@ -6,7 +6,7 @@ use ctl_error::*;
 use ctl_info::*;
 use ctl_type::*;
 use ctl_value::*;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 use std::ffi::CString;
 
 #[cfg(target_os = "freebsd")]
@@ -42,7 +42,7 @@ pub fn name2oid(name: &str) -> Result<Vec<libc::c_int>, SysctlError> {
     Ok(res)
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
 pub fn oidfmt(oid: &[libc::c_int]) -> Result<CtlInfo, SysctlError> {
     // Request command for type info
     let mut qoid: Vec<libc::c_int> = vec![0, 4];
@@ -87,7 +87,7 @@ pub fn oidfmt(oid: &[libc::c_int]) -> Result<CtlInfo, SysctlError> {
     Ok(s)
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 pub fn oidfmt(oid: &[libc::c_int]) -> Result<CtlInfo, SysctlError> {
     // Request command for type info
     let mut qoid: Vec<libc::c_int> = vec![0, 4];
@@ -138,7 +138,7 @@ pub fn oidfmt(oid: &[libc::c_int]) -> Result<CtlInfo, SysctlError> {
     Ok(s)
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
 pub fn value_oid(oid: &[i32]) -> Result<CtlValue, SysctlError> {
     let info: CtlInfo = oidfmt(&oid)?;
 
@@ -227,7 +227,7 @@ pub fn value_oid(oid: &[i32]) -> Result<CtlValue, SysctlError> {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 pub fn value_oid(oid: &mut Vec<i32>) -> Result<CtlValue, SysctlError> {
     let info: CtlInfo = oidfmt(&oid)?;
 
@@ -315,7 +315,7 @@ pub fn value_oid(oid: &mut Vec<i32>) -> Result<CtlValue, SysctlError> {
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
 pub fn value_oid_as<T>(oid: &[i32]) -> Result<Box<T>, SysctlError> {
     let val_enum = value_oid(oid)?;
 
@@ -359,7 +359,7 @@ pub fn value_oid_as<T>(oid: &[i32]) -> Result<Box<T>, SysctlError> {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 pub fn value_oid_as<T>(oid: &mut Vec<i32>) -> Result<Box<T>, SysctlError> {
     let val_enum = value_oid(oid)?;
 
@@ -403,7 +403,7 @@ pub fn value_oid_as<T>(oid: &mut Vec<i32>) -> Result<Box<T>, SysctlError> {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 pub fn value_name(name: &str, ctl_type: CtlType, fmt: &str) -> Result<CtlValue, SysctlError> {
     let name = CString::new(name)?;
 
@@ -484,7 +484,7 @@ pub fn value_name(name: &str, ctl_type: CtlType, fmt: &str) -> Result<CtlValue, 
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 pub fn value_name_as<T>(name: &str, ctl_type: CtlType, fmt: &str) -> Result<Box<T>, SysctlError> {
     let val_enum = value_name(name, ctl_type, fmt)?;
 
@@ -556,7 +556,7 @@ fn value_to_bytes(value: CtlValue) -> Result<Vec<u8>, SysctlError> {
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
 pub fn set_oid_value(oid: &[libc::c_int], value: CtlValue) -> Result<CtlValue, SysctlError> {
     let info: CtlInfo = oidfmt(&oid)?;
 
@@ -592,7 +592,7 @@ pub fn set_oid_value(oid: &[libc::c_int], value: CtlValue) -> Result<CtlValue, S
     self::value_oid(oid)
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 pub fn set_oid_value(oid: &mut Vec<libc::c_int>, value: CtlValue) -> Result<CtlValue, SysctlError> {
     let info: CtlInfo = oidfmt(&oid)?;
 
@@ -642,7 +642,7 @@ pub fn set_oid_value(oid: &mut Vec<libc::c_int>, value: CtlValue) -> Result<CtlV
     self::value_oid(oid)
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 pub fn set_name_value(
     name: &str,
     info_ctl_type: CtlType,
@@ -690,7 +690,7 @@ pub fn set_name_value(
     self::value_name(name, ctl_type, fmt)
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
 pub fn oid2description(oid: &[libc::c_int]) -> Result<String, SysctlError> {
     // Request command for description
     let mut qoid: Vec<libc::c_int> = vec![0, 5];
@@ -720,7 +720,7 @@ pub fn oid2description(oid: &[libc::c_int]) -> Result<String, SysctlError> {
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
 pub fn oid2name(oid: &[libc::c_int]) -> Result<String, SysctlError> {
     // Request command for name
     let mut qoid: Vec<libc::c_int> = vec![0, 1];
@@ -750,7 +750,7 @@ pub fn oid2name(oid: &[libc::c_int]) -> Result<String, SysctlError> {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 pub fn oid2name(oid: &Vec<libc::c_int>) -> Result<String, SysctlError> {
     // Request command for name
     let mut qoid: Vec<libc::c_int> = vec![0, 1];
@@ -780,7 +780,7 @@ pub fn oid2name(oid: &Vec<libc::c_int>) -> Result<String, SysctlError> {
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
 pub fn next_oid(oid: &[libc::c_int]) -> Result<Option<Vec<libc::c_int>>, SysctlError> {
     // Request command for next oid
     let mut qoid: Vec<libc::c_int> = vec![0, 2];
@@ -819,7 +819,7 @@ pub fn next_oid(oid: &[libc::c_int]) -> Result<Option<Vec<libc::c_int>>, SysctlE
     Ok(Some(res))
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))]
 pub fn next_oid(oid: &Vec<libc::c_int>) -> Result<Option<Vec<libc::c_int>>, SysctlError> {
     // Request command for next oid
     let mut qoid: Vec<libc::c_int> = vec![0, 2];
@@ -926,7 +926,7 @@ mod tests_freebsd {
     }
 }
 
-#[cfg(all(test, any(target_os = "macos", target_os = "ios")))]
+#[cfg(all(test, any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos")))]
 mod tests_macos {
     #[test]
     fn ctl_mib() {


### PR DESCRIPTION
This commit extends platform support to include tvOS and visionOS alongside existing macOS and iOS targets. Specifically:

- Updated conditional compilation flags to include `target_os = "tvos"` and `target_os = "visionos"` where appropriate
- Expanded platform-specific code paths to handle these new targets
- Ensured consistent behavior across all Apple platforms (macOS, iOS, tvOS, visionOS)

This change allows the sysctl crate to be used on a wider range of Apple devices and platforms while maintaining existing functionality.